### PR TITLE
schemable: implement Targets()

### DIFF
--- a/schemable.go
+++ b/schemable.go
@@ -44,11 +44,11 @@ func WithTransaction(ctx context.Context, opts *sql.TxOptions) (context.Context,
 	return WithClient(ctx, t), t, err
 }
 
-// Targets returns a slice of Target records from the given Recorders.
+// Targets returns a slice of target records from the given Recorders.
 func Targets[T any](recs []*Recorder[T]) []*T {
 	targets := make([]*T, len(recs))
 	for i, r := range recs {
-		targets[i] = recs[i].Target
+		targets[i] = r.Target
 	}
 	return targets
 }

--- a/schemable.go
+++ b/schemable.go
@@ -44,6 +44,15 @@ func WithTransaction(ctx context.Context, opts *sql.TxOptions) (context.Context,
 	return WithClient(ctx, t), t, err
 }
 
+// Targets returns a slice of Target records from the given Recorders.
+func Targets[T any](recs []*Recorder[T]) []*T {
+	targets := make([]*T, len(recs))
+	for i, r := range recs {
+		targets[i] = recs[i].Target
+	}
+	return targets
+}
+
 type key int
 
 var clientKey = key(1)

--- a/schemabletest/clienttests.go
+++ b/schemabletest/clienttests.go
@@ -39,8 +39,8 @@ func Run(t *testing.T, c *schemable.DBClient) {
 			t.Fatalf("invalid targets: %T %+v", targets, targets)
 		}
 		if targets[0].ID != 1 || targets[1].ID != 2 || targets[2].ID != 3 {
-			for i, t := range targets {
-				t.Errorf("target %d: %T %+v", i, t, t)
+			for i, tg := range targets {
+				t.Errorf("target %d: %T %+v", i, tg, tg)
 			}
 		}
 	})

--- a/schemabletest/clienttests.go
+++ b/schemabletest/clienttests.go
@@ -28,13 +28,13 @@ func Run(t *testing.T, c *schemable.DBClient) {
 	TransactionTests(t, c)
 
 	t.Run("Targets()", func(t *testing.T) {
-		recs := []*Recorder[ComicTitle]{
+		recs := []*schemable.Recorder[ComicTitle]{
 			ComicTitles.Record(&ComicTitle{ID: 1}),
 			ComicTitles.Record(&ComicTitle{ID: 2}),
 			ComicTitles.Record(&ComicTitle{ID: 3}),
 		}
 
-		targets := Targets[ComicTitle](recs)
+		targets := schemable.Targets[ComicTitle](recs)
 		if len(targets) != 3 {
 			t.Fatalf("invalid targets: %T %+v", targets, targets)
 		}

--- a/schemabletest/clienttests.go
+++ b/schemabletest/clienttests.go
@@ -26,4 +26,22 @@ func Run(t *testing.T, c *schemable.DBClient) {
 	})
 
 	TransactionTests(t, c)
+
+	t.Run("Targets()", func(t *testing.T) {
+		recs := []*Recorder[ComicTitle]{
+			ComicTitles.Record(&ComicTitle{ID: 1}),
+			ComicTitles.Record(&ComicTitle{ID: 2}),
+			ComicTitles.Record(&ComicTitle{ID: 3}),
+		}
+
+		targets := Targets[ComicTitle](recs)
+		if len(targets) != 3 {
+			t.Fatalf("invalid targets: %T %+v", targets, targets)
+		}
+		if targets[0].ID != 1 || targets[1].ID != 2 || targets[2].ID != 3 {
+			for i, t := range targets {
+				t.Errorf("target %d: %T %+v", i, t, t)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Converts a slice of `Recorder[T]` instances to a slice of the targets themselves.