### PR TITLE
add (*Schemer[T]) First()

### DIFF
--- a/schemabletest/schemertests.go
+++ b/schemabletest/schemertests.go
@@ -16,7 +16,7 @@ func SchemerTests(t *testing.T, ctx context.Context) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if rec.Target.Name != "two" {
+			if rec.Target.Name != "three" {
 				recorderErr(t, rec)
 			}
 		})

--- a/schemabletest/schemertests.go
+++ b/schemabletest/schemertests.go
@@ -9,6 +9,18 @@ import (
 
 func SchemerTests(t *testing.T, ctx context.Context) {
 	t.Run("Schemer", func(t *testing.T) {
+		t.Run("First()", func(t *testing.T) {
+			rec, err := ComicTitles.First(ctx, func(q sq.SelectBuilder) sq.SelectBuilder {
+				return q.OrderBy("id DESC")
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if rec.Target.Name != "two" {
+				recorderErr(t, recs[0])
+			}
+		})
+
 		t.Run("ListWhere()", func(t *testing.T) {
 			recs, err := ComicTitles.ListWhere(ctx, func(q sq.SelectBuilder) sq.SelectBuilder {
 				return q.Where(sq.Eq{"name": "one"})

--- a/schemabletest/schemertests.go
+++ b/schemabletest/schemertests.go
@@ -17,7 +17,7 @@ func SchemerTests(t *testing.T, ctx context.Context) {
 				t.Fatal(err)
 			}
 			if rec.Target.Name != "two" {
-				recorderErr(t, recs[0])
+				recorderErr(t, rec)
 			}
 		})
 

--- a/schemer.go
+++ b/schemer.go
@@ -36,7 +36,7 @@ func Bind[T any](table string) *Schemer[T] {
 func (s *Schemer[T]) First(ctx context.Context, fn WhereFunc) (*Recorder[T], error) {
 	c := ClientFrom(ctx)
 	if c == nil {
-		return false, errors.New("no client in context")
+		return nil, errors.New("no client in context")
 	}
 
 	q := fn(c.Builder().Select(s.Columns(true)...).From(s.table)).Limit(1)
@@ -45,7 +45,7 @@ func (s *Schemer[T]) First(ctx context.Context, fn WhereFunc) (*Recorder[T], err
 		return nil, err
 	}
 
-	rec = s.Record(nil)
+	rec := s.Record(nil)
 	return rec, c.QueryRow(ctx, qu, args...).Scan(rec.fieldRefs(true)...)
 }
 


### PR DESCRIPTION
Implements `First()` so you don't have to call `ListWhere` and process the returned `[]*Recorder[T]`.