### PR TITLE
Log query ctx

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ type Client interface {
 
 // QueryLogger is a wrapper for a type that logs SQL queries.
 type QueryLogger interface {
-	LogQuery(q string, args []any)
+	LogQuery(ctx context.Context, q string, args []any)
 }
 
 // DBClient is a wrapper around an *sql.DB instance, a QueryLogger, and a
@@ -65,14 +65,14 @@ func (c *DBClient) Builder() *sq.StatementBuilderType {
 // Exec executes a query without returning any rows. The args are for any
 // placeholder parameters in the query.
 func (c *DBClient) Exec(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	c.logger.LogQuery(q, args)
+	c.logger.LogQuery(ctx, q, args)
 	return c.db.ExecContext(ctx, q, args...)
 }
 
 // Query executes a query that returns rows, typically a SELECT. The args are
 // for any placeholder parameters in the query.
 func (c *DBClient) Query(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	c.logger.LogQuery(q, args)
+	c.logger.LogQuery(ctx, q, args)
 	return c.db.QueryContext(ctx, q, args...)
 }
 
@@ -82,7 +82,7 @@ func (c *DBClient) Query(ctx context.Context, q string, args ...any) (*sql.Rows,
 // will return ErrNoRows. Otherwise, the *Row's Scan scans the first selected
 // row and discards the rest.
 func (c *DBClient) QueryRow(ctx context.Context, q string, args ...any) *sql.Row {
-	c.logger.LogQuery(q, args)
+	c.logger.LogQuery(ctx, q, args)
 	return c.db.QueryRowContext(ctx, q, args...)
 }
 
@@ -128,14 +128,14 @@ func (c *TxnClient) Rollback() error {
 // Exec executes a query without returning any rows. The args are for any
 // placeholder parameters in the query.
 func (c *TxnClient) Exec(ctx context.Context, q string, args ...any) (sql.Result, error) {
-	c.logger.LogQuery(q, args)
+	c.logger.LogQuery(ctx, q, args)
 	return c.tx.ExecContext(ctx, q, args...)
 }
 
 // Query executes a query that returns rows, typically a SELECT. The args are
 // for any placeholder parameters in the query.
 func (c *TxnClient) Query(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
-	c.logger.LogQuery(q, args)
+	c.logger.LogQuery(ctx, q, args)
 	return c.tx.QueryContext(ctx, q, args...)
 }
 
@@ -145,7 +145,7 @@ func (c *TxnClient) Query(ctx context.Context, q string, args ...any) (*sql.Rows
 // will return ErrNoRows. Otherwise, the *Row's Scan scans the first selected
 // row and discards the rest.
 func (c *TxnClient) QueryRow(ctx context.Context, q string, args ...any) *sql.Row {
-	c.logger.LogQuery(q, args)
+	c.logger.LogQuery(ctx, q, args)
 	return c.tx.QueryRowContext(ctx, q, args...)
 }
 
@@ -156,7 +156,7 @@ func (c *TxnClient) Builder() *sq.StatementBuilderType {
 
 type noLogger struct{}
 
-func (l *noLogger) LogQuery(q string, args []any) {
+func (l *noLogger) LogQuery(ctx context.Context, q string, args []any) {
 }
 
 var nilLogger = &noLogger{}

--- a/recorder.go
+++ b/recorder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 )
 
 // Recorder records changes to Target of type T using its Schemer.
@@ -27,8 +28,11 @@ func (r *Recorder[T]) Load(ctx context.Context) error {
 		return err
 	}
 
+
+	start := time.Now()
 	refs := r.fieldRefs(false)
 	err = c.QueryRow(ctx, qu, args...).Scan(refs...)
+	c.LogQuery(WithDBDuration(ctx, start), qu, args)
 	if err == nil {
 		r.setValues()
 	}
@@ -49,8 +53,10 @@ func (r *Recorder[T]) LoadWhere(ctx context.Context, pred any, args ...any) erro
 		return err
 	}
 
+	start := time.Now()
 	refs := r.fieldRefs(true)
 	err = c.QueryRow(ctx, qu, args...).Scan(refs...)
+	c.LogQuery(WithDBDuration(ctx, start), qu, args)
 	if err == nil {
 		r.setValues()
 	}
@@ -77,7 +83,9 @@ func (r *Recorder[T]) Insert(ctx context.Context) error {
 		return err
 	}
 
+	start := time.Now()
 	res, err := c.Exec(ctx, qu, args...)
+	c.LogQuery(WithDBDuration(ctx, start), qu, args)
 	if err != nil {
 		return err
 	}
@@ -121,7 +129,10 @@ func (r *Recorder[T]) Update(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	start := time.Now()
 	_, err = c.Exec(ctx, qu, args...)
+	c.LogQuery(WithDBDuration(ctx, start), qu, args)
 	if err == nil {
 		r.setValues()
 	}
@@ -142,7 +153,9 @@ func (r *Recorder[T]) Delete(ctx context.Context) error {
 		return err
 	}
 
+	start := time.Now()
 	_, err = c.Exec(ctx, qu, args...)
+	c.LogQuery(WithDBDuration(ctx, start), qu, args)
 	return err
 }
 

--- a/schemabletest/schemabletest.go
+++ b/schemabletest/schemabletest.go
@@ -57,5 +57,5 @@ type testLogger struct {
 }
 
 func (l *testLogger) LogQuery(ctx context.Context, q string, args []any) {
-	l.t.Logf("SQL: %s; ARGS: %+v", q, args)
+	l.t.Logf("SQL: %s; ARGS: %+v, TIME: %s", q, args, schemable.DBDurationFrom(ctx))
 }

--- a/schemabletest/schemabletest.go
+++ b/schemabletest/schemabletest.go
@@ -56,6 +56,6 @@ type testLogger struct {
 	t *testing.T
 }
 
-func (l *testLogger) LogQuery(q string, args []any) {
+func (l *testLogger) LogQuery(ctx context.Context, q string, args []any) {
 	l.t.Logf("SQL: %s; ARGS: %+v", q, args)
 }


### PR DESCRIPTION
This pulls the logging out of the client so that the query execution duration can be logged. This is so the duration includes the time to scan the rows, which is typically handled in the Schemer or Recorder funcs.