### PR TITLE
don't set recorder's internal values

### DIFF
--- a/schemabletest/schemertests.go
+++ b/schemabletest/schemertests.go
@@ -19,6 +19,9 @@ func SchemerTests(t *testing.T, ctx context.Context) {
 			if rec.Target.Name != "three" {
 				recorderErr(t, rec)
 			}
+			if v := rec.UpdatedValues(); len(v) > 0 {
+				t.Errorf("has updated values: %+v", v)
+			}
 		})
 
 		t.Run("ListWhere()", func(t *testing.T) {
@@ -39,6 +42,10 @@ func SchemerTests(t *testing.T, ctx context.Context) {
 			if recs[0].Target.Name != "one" {
 				recorderErr(t, recs[0])
 			}
+
+			if v := recs[0].UpdatedValues(); len(v) > 0 {
+				t.Errorf("has updated values: %+v", v)
+			}
 		})
 
 		t.Run("List()", func(t *testing.T) {
@@ -51,8 +58,12 @@ func SchemerTests(t *testing.T, ctx context.Context) {
 				t.Fatal("no records")
 			}
 
-			if recs[0].Target.Name != "two" {
+			if recs[0].Target.Name != "direct" {
 				recorderErr(t, recs[0])
+			}
+
+			if v := recs[0].UpdatedValues(); len(v) > 0 {
+				t.Errorf("has updated values: %+v", v)
 			}
 		})
 

--- a/schemer.go
+++ b/schemer.go
@@ -48,6 +48,7 @@ func (s *Schemer[T]) First(ctx context.Context, fn WhereFunc) (*Recorder[T], err
 	rec := s.Record(nil)
 	start := time.Now()
 	err = c.QueryRow(ctx, qu, args...).Scan(rec.fieldRefs(true)...)
+	rec.setValues()
 	c.LogQuery(WithDBDuration(ctx, start), qu, args)
 	return rec, err
 }
@@ -143,9 +144,7 @@ func (s *Schemer[T]) Record(tgt *T) *Recorder[T] {
 	if tgt == nil {
 		tgt = new(T)
 	}
-	rec := &Recorder[T]{Schemer: s, Target: tgt}
-	rec.setValues()
-	return rec
+	return &Recorder[T]{Schemer: s, Target: tgt}
 }
 
 // Table returns the table name that the Schemer's type T uses.


### PR DESCRIPTION
Schemable shouldn't trust that objects passed to `(*Recorder[T]) Record()` have all the fields set correctly. This affects `(*Recorder[T]) UpdatedValues()`, which shows up empty.

This then breaks the following, because `Update()` returns fast if there are no updated values to write to the DB.

```go
rec := Schemes.Record(&Object{ID: 1, Name: "First"})
rec.Update(ctx)
```

There are two ways around this already:

```go
// populate from the db first
rec := Schemes.Record(&Object{ID: 1})
rec.Load(ctx)
rec.Target.Name = "First"
rec.Load(ctx)

// avoid db call, change values after `Record()`
rec := Schemes.Record(&Object{ID: 1})
rec.Target.Name = "First"
rec.Update(ctx)
```

But I think the first option is an obvious choice in solutions, and the fact it doesn't work is surprising.